### PR TITLE
Fix  850ff40095e02771a0b7b0518ef9ba2678200096

### DIFF
--- a/src/fsevent.rs
+++ b/src/fsevent.rs
@@ -354,8 +354,10 @@ impl Watcher for FsEventWatcher {
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
         self.stop();
-        try!(self.append_path(path, recursive_mode));
-        self.run()
+        let result = self.append_path(path, recursive_mode);  
+        // ignore return error: may be empty path list
+        let _ = self.run();
+        result
     }
 
     fn unwatch<P: AsRef<Path>>(&mut self, path: P) -> Result<()> {


### PR DESCRIPTION
With 850ff40095e02771a0b7b0518ef9ba2678200096 I introduced a bug,
when a path couldn't be found the watcher wasn't started again. This
should fix issue #105 correctly.