### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ categories = ["filesystem"]
 [dependencies]
 bitflags = "^0.7.0"
 libc = "^0.2.4"
-time = "^0.1.34"
 filetime = "^0.1.9"
 walkdir = "^0.1.5"
 

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -11,16 +11,15 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock, Mutex};
 use std::sync::mpsc::Sender;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use super::{Error, RawEvent, DebouncedEvent, op, Result, Watcher, RecursiveMode};
 use super::debounce::{Debounce, EventTx};
 
-extern crate time;
 extern crate walkdir;
 
 struct PathData {
     mtime: u64,
-    last_check: f64,
+    last_check: Instant,
 }
 
 struct WatchData {
@@ -64,7 +63,7 @@ impl PollWatcher {
                 }
 
                 if let Ok(mut watches) = watches.lock() {
-                    let current_time = time::precise_time_s();
+                    let current_time = Instant::now();
 
                     for (watch, &mut WatchData { is_recursive, ref mut paths }) in
                         watches.iter_mut() {
@@ -195,7 +194,7 @@ impl Watcher for PollWatcher {
 
     fn watch<P: AsRef<Path>>(&mut self, path: P, recursive_mode: RecursiveMode) -> Result<()> {
         if let Ok(mut watches) = self.watches.lock() {
-            let current_time = time::precise_time_s();
+            let current_time = Instant::now();
 
             let watch = path.as_ref().to_owned();
 

--- a/tests/debounce.rs
+++ b/tests/debounce.rs
@@ -2,7 +2,6 @@
 
 extern crate notify;
 extern crate tempdir;
-extern crate time;
 
 #[macro_use]
 mod utils;
@@ -10,19 +9,19 @@ mod utils;
 use notify::*;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempdir::TempDir;
 use utils::*;
 
-const DELAY_S: u64 = 1;
-const TIMEOUT_S: f64 = 1.0;
+const DELAY_MS: u64 = 1000;
+const TIMEOUT_MS: u64 = 1000;
 
 fn recv_events_debounced(rx: &mpsc::Receiver<DebouncedEvent>) -> Vec<DebouncedEvent> {
-    let deadline = time::precise_time_s() + DELAY_S as f64 + TIMEOUT_S;
+    let start = Instant::now();
 
     let mut events = Vec::new();
 
-    while time::precise_time_s() < deadline {
+    while start.elapsed() < Duration::from_millis(DELAY_MS + TIMEOUT_MS) {
         match rx.try_recv() {
             Ok(event) => events.push(event),
             Err(mpsc::TryRecvError::Empty) => (),
@@ -40,7 +39,7 @@ fn create_file() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -61,7 +60,7 @@ fn write_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.write("file1");
@@ -83,10 +82,10 @@ fn write_long_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
-    let wait = Duration::from_millis(DELAY_S * 500);
+    let wait = Duration::from_millis(DELAY_MS / 2);
     tdir.write("file1");
     thread::sleep(wait);
     tdir.write("file1");
@@ -127,7 +126,7 @@ fn modify_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.chmod("file1");
@@ -156,7 +155,7 @@ fn delete_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.remove("file1");
@@ -178,7 +177,7 @@ fn rename_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("file1", "file2");
@@ -196,7 +195,7 @@ fn create_write_modify_file() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -215,7 +214,7 @@ fn create_delete_file() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -236,7 +235,7 @@ fn delete_create_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.remove("file1");
@@ -256,7 +255,7 @@ fn create_rename_file() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -274,7 +273,7 @@ fn create_rename_delete_file() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -309,7 +308,7 @@ fn create_rename_overwrite_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -341,7 +340,7 @@ fn create_rename_write_create() { // fsevents
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -364,7 +363,7 @@ fn create_rename_remove_create() { // fsevents
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("file1");
@@ -402,12 +401,12 @@ fn move_out_sleep_move_in() { // fsevents
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("watch_dir"), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("watch_dir/file1");
     tdir.rename("watch_dir/file1", "file1");
-    sleep(DELAY_S * 1000 + 10);
+    sleep(DELAY_MS + 10);
     tdir.rename("file1", "watch_dir/file2");
 
     if cfg!(target_os="macos") {
@@ -434,7 +433,7 @@ fn write_rename_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.write("file1");
@@ -459,7 +458,7 @@ fn rename_write_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("file1", "file2");
@@ -485,7 +484,7 @@ fn modify_rename_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.chmod("file1");
@@ -519,7 +518,7 @@ fn rename_modify_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("file1", "file2");
@@ -554,7 +553,7 @@ fn rename_rename_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("file1", "file2");
@@ -578,7 +577,7 @@ fn write_delete_file() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.write("file1");
@@ -598,7 +597,7 @@ fn create_directory() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -619,7 +618,7 @@ fn modify_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.chmod("dir1");
@@ -648,7 +647,7 @@ fn delete_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.remove("dir1");
@@ -670,7 +669,7 @@ fn rename_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("dir1", "dir2");
@@ -688,7 +687,7 @@ fn create_modify_directory() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -706,7 +705,7 @@ fn create_delete_directory() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -727,7 +726,7 @@ fn delete_create_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.remove("dir1");
@@ -747,7 +746,7 @@ fn create_rename_directory() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -765,7 +764,7 @@ fn create_rename_delete_directory() {
     sleep_macos(10);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -794,7 +793,7 @@ fn create_rename_overwrite_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.create("dir1");
@@ -823,7 +822,7 @@ fn modify_rename_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.chmod("dir1");
@@ -858,7 +857,7 @@ fn rename_modify_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("dir1", "dir2");
@@ -906,7 +905,7 @@ fn rename_rename_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.rename("dir1", "dir2");
@@ -930,7 +929,7 @@ fn modify_delete_directory() {
     sleep_macos(35_000);
 
     let (tx, rx) = mpsc::channel();
-    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_secs(DELAY_S)).expect("failed to create debounced watcher");
+    let mut watcher: RecommendedWatcher = Watcher::new(tx, Duration::from_millis(DELAY_MS)).expect("failed to create debounced watcher");
     watcher.watch(tdir.mkpath("."), RecursiveMode::Recursive).expect("failed to watch directory");
 
     tdir.chmod("dir1");

--- a/tests/event_path.rs
+++ b/tests/event_path.rs
@@ -1,6 +1,5 @@
 extern crate notify;
 extern crate tempdir;
-extern crate time;
 
 mod utils;
 

--- a/tests/fsevents.rs
+++ b/tests/fsevents.rs
@@ -2,7 +2,6 @@
 
 extern crate notify;
 extern crate tempdir;
-extern crate time;
 
 mod utils;
 

--- a/tests/notify.rs
+++ b/tests/notify.rs
@@ -1,6 +1,5 @@
 extern crate notify;
 extern crate tempdir;
-extern crate time;
 
 mod utils;
 

--- a/tests/watcher.rs
+++ b/tests/watcher.rs
@@ -1,6 +1,5 @@
 extern crate notify;
 extern crate tempdir;
-extern crate time;
 
 mod utils;
 
@@ -11,7 +10,7 @@ use std::thread;
 use std::env;
 
 #[cfg(all(feature = "manual_tests", target_os="linux"))]
-use std::time::Duration;
+use std::time::{Duration, Instant};
 #[cfg(all(feature = "manual_tests", target_os="linux"))]
 use std::io::prelude::*;
 #[cfg(all(feature = "manual_tests", target_os="linux"))]
@@ -250,10 +249,10 @@ fn inotify_queue_overflow() {
 
     sleep(100);
 
-    let deadline = time::precise_time_s() + 5.0;
+    let start = Instant::now();
 
     let mut rescan_found = false;
-    while !rescan_found && time::precise_time_s() < deadline {
+    while !rescan_found && start.elapsed().as_secs() < 5 {
         match rx.try_recv() {
             Ok(RawEvent{op: Ok(op::RESCAN), ..}) => rescan_found = true,
             Ok(RawEvent{op: Err(e), ..}) => panic!("unexpected event err: {:?}", e),


### PR DESCRIPTION
Cargo will still pull ``time`` in as a dependency at times through mio, but mio 0.6 doesn't depend on ``time``