### PR TITLE
Detect moves if two connected move events are split between two mio polls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+## 4.0.1
+
+- FIX: \[Linux\] Detect moves if two connected move events are split between two mio polls
+
+
 ## 4.0.0
 
 - CHANGE: \[Linux\] Update dependency to inotify 0.3.0.


### PR DESCRIPTION
When receiving only the first part of a move event with inotify (IN_MOVED_FROM) it is unclear whether the second part (IN_MOVED_TO) will arrive because the file or directory could just have been moved out of the watched directory. So it's necessary to wait for possible subsequent events in case it's a complete move event but also to make sure that the first part of the event is handled in a timely manner in case no subsequent events arrive.

My solution to this is pretty hacky. I'm just spawning a new thread in those cases and wait for 10 ms. This is not optimal but it should happen rarely. I also looked into using mio for this, but I didn't come far.

I didn't test it, but I think the fsevents back-end has the same problem.

@passcod: I saw that you started working on re-write using futures. That's great. And it should make solving this problem easier in the future.