### PR TITLE
Make DebouncedEvent be Clone, expose is_recursive

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub struct RawEvent {
 
 unsafe impl Send for RawEvent {}
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Event delivered when action occurs on a watched path in debounced mode
 pub enum DebouncedEvent {
     /// `NoticeWrite` is emitted immediately after the first write event for the path.


### PR DESCRIPTION
A speculative PR:

These are two very small changes that would be useful to me. Getting #131 onto crates.io would be appreciated, and if you want to include these that would be additionally so; but I do have some workarounds in place already so this is less important.

If you were going to do a bump for crates.io, and could give an up or down vote on #118 first, it could go in at the same time?

Thanks!