### PR TITLE
Add some backend compliance tests

### DIFF
--- a/backend/src/compliance.rs
+++ b/backend/src/compliance.rs
@@ -22,6 +22,9 @@
 ///  - `WatchFolders`
 ///  - `WatchFiles`
 ///  - `WatchRecursively`
+///  - `EmitOnAccess`
+///  - `FollowSymlinks`
+///  - `TrackRelated`
 ///
 /// For internal reasons, tests covering events which your backend explicitely does not support
 /// will still be run, but they will always pass.
@@ -31,12 +34,14 @@ macro_rules! test_compliance {
         use futures::Async;
         use futures::stream::Stream;
         use notify_backend::prelude::*;
-        use std::fs::File;
+        use std::fs::{File, rename};
         use std::io::Write;
         use std::path::PathBuf;
         use std::thread::sleep;
         use std::time::Duration;
         use tempdir::TempDir;
+        #[cfg(unix)]
+        use std::os::unix::fs::symlink;
 
         fn settle_events(backend: &mut $Backend) -> Vec<Event> {
             sleep(Duration::from_millis(25));
@@ -143,6 +148,111 @@ macro_rules! test_compliance {
 
                 let modifies = events.iter().filter(|e| e.kind.is_modify());
                 assert!(modifies.count() > 0, "receive at least one Modify event");
+            }
+        }
+
+        #[test]
+        fn cap_emit_on_access() {
+            if !$Backend::capabilities().contains(&Capability::EmitOnAccess) {
+                assert!(true);
+                return;
+            }
+
+            if $Backend::capabilities().contains(&Capability::WatchFiles) {
+                let dir = TempDir::new("cap_emit_on_access").expect("create tmp dir");
+                let filename = String::from("file");
+                let filepath = dir.path().join(&filename);
+                File::create(&filepath).expect("create tmp file");
+
+                let mut backend = $Backend::new(vec![filepath.clone()]).expect("init backend");
+
+                File::open(&filepath).expect("open tmp file");
+
+                {
+                    let events = settle_events(&mut backend);
+                    assert!(events.len() > 0, "receive at least one event");
+
+                    let accesses = events.iter().filter(|e| e.kind.is_access());
+                    assert!(accesses.count() > 0, "receive at least one Access event");
+                }
+            } else {
+                unimplemented!();
+            }
+        }
+
+        #[test]
+        fn cap_follow_symlinks() {
+            if !$Backend::capabilities().contains(&Capability::FollowSymlinks) {
+                assert!(true);
+                return;
+            }
+
+            if $Backend::capabilities().contains(&Capability::WatchFiles) {
+                let dir = TempDir::new("cap_emit_on_access").expect("create tmp dir");
+                let filename = String::from("file");
+                let filepath = dir.path().join(&filename);
+                let mut file = File::create(&filepath).expect("create tmp file");
+                let linkname = String::from("link");
+                let linkpath = dir.path().join(&linkname);
+                if cfg!(unix) {
+                    symlink(&filepath, &linkpath).expect("create symlink");
+                } else {
+                    unimplemented!();
+                }
+
+                let mut backend = $Backend::new(vec![linkpath]).expect("init backend");
+
+                writeln!(file, "Everybody can talk to crickets, the trick is getting them to talk back.").expect("write to file");
+
+                {
+                    let events = settle_events(&mut backend);
+                    assert!(events.len() > 0, "receive at least one event");
+
+                    let modifies = events.iter().filter(|e| e.kind.is_modify());
+                    assert!(modifies.count() > 0, "receive at least one Modify event");
+                }
+            } else {
+                unimplemented!();
+            }
+        }
+
+        #[test]
+        fn cap_track_related() {
+            if !$Backend::capabilities().contains(&Capability::TrackRelated) {
+                assert!(true);
+                return;
+            }
+
+            if $Backend::capabilities().contains(&Capability::WatchFolders) {
+                let dir = TempDir::new("cap_emit_on_access").expect("create tmp dir");
+                let path = dir.path().to_path_buf();
+                let filename_a = String::from("file_a");
+                let filepath_a = dir.path().join(&filename_a);
+                let filename_b = String::from("file_b");
+                let filepath_b = dir.path().join(&filename_b);
+                File::create(&filepath_a).expect("create tmp file");
+
+                let mut backend = $Backend::new(vec![path]).expect("init backend");
+
+                rename(&filepath_a, &filepath_b).expect("rename file");
+
+                {
+                    let events = settle_events(&mut backend);
+                    assert!(events.len() > 0, "receive at least one event");
+
+                    let modify_events_with_relids = events.iter().filter(|e| e.kind.is_modify() && e.relid.is_some()).collect::<Vec<_>>();
+
+                    if modify_events_with_relids.len() > 0 {
+                        let relid = modify_events_with_relids[0].relid;
+                        let modifies = modify_events_with_relids.iter().filter(|e| e.relid == relid);
+                        assert!(modifies.count() == 2, "receive exactly two related Modify events");
+                    } else {
+                        let modifies = events.iter().filter(|e| e.kind.is_modify() && e.paths.len() > 1);
+                        assert!(modifies.count() > 0, "receive related Modify events");
+                    }
+                }
+            } else {
+                unimplemented!();
             }
         }
     )


### PR DESCRIPTION
Here are some (incomplete) backend compliance tests for EmitOnAccess, FollowSymlinks and TrackRelated as mentioned in #137.