### PR TITLE
Poll backend: Release the lock while we sleep.

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -165,9 +165,9 @@ impl PollWatcher {
                             (*paths).remove(&path);
                         }
                     }
-
-                    thread::sleep(delay);
                 }
+
+                thread::sleep(delay);
             }
         });
     }


### PR DESCRIPTION
If we sleep while holding the lock, we can block calls to watch().

Seeing this on FreeBSD, where even the most trivial example program will randomly hang while setting up watches.