### PR TITLE
Remove timeout on inotify poll

### DIFF
--- a/src/inotify.rs
+++ b/src/inotify.rs
@@ -146,11 +146,10 @@ impl EventLoop {
 
     fn event_loop_thread(mut self) {
         let mut events = mio::Events::with_capacity(16);
-        let timeout = Duration::from_millis(100);
         loop {
             // Wait for something to happen.
             self.poll
-                .poll(&mut events, Some(timeout))
+                .poll(&mut events, None)
                 .expect("poll failed");
 
             // Process whatever happened.


### PR DESCRIPTION
This was added in #162 but I don't think it's actually needed. All events go through this, even shutdown events (so we don't need to handle signals ourselves / use `poll_interruptible`).

Reported in #173