### PR TITLE
impl Sync for PollWatcher

### DIFF
--- a/src/poll.rs
+++ b/src/poll.rs
@@ -311,3 +311,6 @@ impl Drop for PollWatcher {
         self.open.store(false, Ordering::Relaxed);
     }
 }
+
+// Because all public methods are `&mut self` it's also perfectly safe to share references.
+unsafe impl Sync for PollWatcher {}


### PR DESCRIPTION
After adding cross compiled binaries for hunter using travis I noticed that it failed building on FreeBSD because PollWatcher doesn't implement Sync. Since all methods take &mut self, I guess this is OK.