### PR TITLE
[libs] Peg filetime to 0.2.5 for rust 1.26.1 compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 bitflags = "^1.0.4"
 libc = "^0.2.4"
-filetime = "^0.2.1"
+filetime = "=0.2.5"
 walkdir = "^2.0.1"
 
 [target.'cfg(target_os="linux")'.dependencies]


### PR DESCRIPTION
After some digging I found that the build failure happens, because filetime changed its interface after version 0.2.5 and requires Rust 2018 now. This shouldn't happen in a minor version, but it did.

The last commit that builds with Rust 1.26.1 is [this one](https://github.com/alexcrichton/filetime/commit/95bbd6351a6f3766e430cba911c3c88115fbb6a0). After that there are various different build failures.

This means any fresh build of notify is going to fail if it picks up the newest filetime version. I fixed this by hard-coding the lastest working version 0.2.5, which makes the build go through.

Since it's unrelated to the PollWatches Sync thing I made this a separate pull request.